### PR TITLE
Add Awareness of protocol strandedness

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This workflow performs a differential expression analysis with STAR and Deseq2.
 
 * Johannes Köster (@johanneskoester), https://koesterlab.github.io
 * Sebastian Schmeier (@sschmeier), https://sschmeier.com
-
+* Jose Maturana (@matrs)
 
 ## Usage
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,12 @@
 # path or URL to sample sheet (TSV format, columns: sample, condition, ...)
 samples: samples.tsv
-# path or URL to sequencing unit sheet (TSV format, columns: sample, unit, fq1, fq2)
-# Units are technical replicates (e.g. lanes, or resequencing of the same biological
-# sample).
+# path or URL to sequencing unit sheet (TSV format, columns: sample, unit, fq1, fq2, 
+# strandedness). Units are technical replicates (e.g. lanes, or resequencing of the 
+# same biological sample).If the column "strandedness" is present (which is optional), 
+# can be empty or has one of these values: 0, yes or reverse. 0 is for unstranded 
+# protocols, yes an reverse follow the nomenclature used in `htseq-count --reverse` 
+# which is referenced in STAR manual section 7, "Counting number of reads per gene".
+
 units: units.tsv
 
 # the sequencing adapter

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ samples: samples.tsv
 # path or URL to sequencing unit sheet (TSV format, columns: sample, unit, fq1, fq2, 
 # strandedness). Units are technical replicates (e.g. lanes, or resequencing of the 
 # same biological sample).If the column "strandedness" is present (which is optional), 
-# can be empty or has one of these values: 0, yes or reverse. 0 is for unstranded 
+# can be empty or has one of these values: none, yes or reverse. none is for unstranded 
 # protocols, yes an reverse follow the nomenclature used in `htseq-count --reverse` 
 # which is referenced in STAR manual section 7, "Counting number of reads per gene".
 

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -1,2 +1,25 @@
 def is_single_end(sample, unit):
     return pd.isnull(units.loc[(sample, unit), "fq2"])
+
+def exist_strandedness(units):
+    return "strandedness" in units.columns
+    
+def strandedness(units):
+    strandedness_list = []
+    if exist_strandedness(units):
+        for unit in units.itertuples():
+            strand_val = units.loc[(unit.sample, unit.unit), "strandedness"]
+            if pd.isnull(strand_val) or int(strand_val) == 0:
+                strandedness_list.append(1) #non stranded protocol
+            elif strand_val == "yes":
+                strandedness_list.append(2) #3rd column
+            elif strand_val == "reverse":
+                strandedness_list.append(3) #4th column, usually for Illumina truseq
+            else:
+                raise ValueError(("'strandedness' column should be empty or have the " 
+                "value 0, 'yes' or 'reverse',instead has the value {}").format(repr(strand_val)))
+    else:
+        strandedness_list.append(1)#non stranded for cases where there isn't a "strandedness" column
+        strandedness_list *= units.shape[0]
+    
+    return strandedness_list

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -9,7 +9,7 @@ def strandedness(units):
     if exist_strandedness(units):
         for unit in units.itertuples():
             strand_val = units.loc[(unit.sample, unit.unit), "strandedness"]
-            if pd.isnull(strand_val) or int(strand_val) == 0:
+            if pd.isnull(strand_val) or strand_val == "0":
                 strandedness_list.append(1) #non stranded protocol
             elif strand_val == "yes":
                 strandedness_list.append(2) #3rd column

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -1,12 +1,9 @@
 def is_single_end(sample, unit):
     return pd.isnull(units.loc[(sample, unit), "fq2"])
-
-def exist_strandedness(units):
-    return "strandedness" in units.columns
     
 def strandedness(units):
     strandedness_list = []
-    if exist_strandedness(units):
+    if "strandedness" in units.columns:
         for unit in units.itertuples():
             strand_val = units.loc[(unit.sample, unit.unit), "strandedness"]
             if pd.isnull(strand_val) or strand_val == "0":
@@ -17,9 +14,9 @@ def strandedness(units):
                 strandedness_list.append(3) #4th column, usually for Illumina truseq
             else:
                 raise ValueError(("'strandedness' column should be empty or have the " 
-                "value 0, 'yes' or 'reverse',instead has the value {}").format(repr(strand_val)))
+                "value 0, 'yes' or 'reverse', instead has the value {}").format(repr(strand_val)))
     else:
-        strandedness_list.append(1)#non stranded for cases where there isn't a "strandedness" column
+        strandedness_list.append(1) #non stranded for cases where there isn't a "strandedness" column
         strandedness_list *= units.shape[0]
     
     return strandedness_list

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -1,22 +1,3 @@
 def is_single_end(sample, unit):
     return pd.isnull(units.loc[(sample, unit), "fq2"])
     
-def strandedness(units):
-    strandedness_list = []
-    if "strandedness" in units.columns:
-        for unit in units.itertuples():
-            strand_val = units.loc[(unit.sample, unit.unit), "strandedness"]
-            if pd.isnull(strand_val) or strand_val == "0":
-                strandedness_list.append(1) #non stranded protocol
-            elif strand_val == "yes":
-                strandedness_list.append(2) #3rd column
-            elif strand_val == "reverse":
-                strandedness_list.append(3) #4th column, usually for Illumina truseq
-            else:
-                raise ValueError(("'strandedness' column should be empty or have the " 
-                "value 0, 'yes' or 'reverse', instead has the value {}").format(repr(strand_val)))
-    else:
-        strandedness_list.append(1) #non stranded for cases where there isn't a "strandedness" column
-        strandedness_list *= units.shape[0]
-    
-    return strandedness_list

--- a/rules/diffexp.smk
+++ b/rules/diffexp.smk
@@ -4,7 +4,8 @@ rule count_matrix:
     output:
         "counts/all.tsv"
     params:
-        samples=units["sample"].tolist()
+        samples=units["sample"].tolist(),
+        coln=strandedness(units)
     conda:
         "../envs/pandas.yaml"
     script:

--- a/rules/diffexp.smk
+++ b/rules/diffexp.smk
@@ -1,3 +1,10 @@
+def exist_strandness(units):
+    if "strandedness" in units.columns:
+        return units["strandedness"].tolist()
+    else:
+        strand_list=["none"]
+        return strand_list*units.shape[0]
+
 rule count_matrix:
     input:
         expand("star/{unit.sample}-{unit.unit}/ReadsPerGene.out.tab", unit=units.itertuples())
@@ -5,7 +12,7 @@ rule count_matrix:
         "counts/all.tsv"
     params:
         samples=units["sample"].tolist(),
-        units=units
+        strand=exist_strandness(units)
     conda:
         "../envs/pandas.yaml"
     script:

--- a/rules/diffexp.smk
+++ b/rules/diffexp.smk
@@ -1,4 +1,4 @@
-def exist_strandness(units):
+def get_strandness(units):
     if "strandedness" in units.columns:
         return units["strandedness"].tolist()
     else:
@@ -12,7 +12,7 @@ rule count_matrix:
         "counts/all.tsv"
     params:
         samples=units["sample"].tolist(),
-        strand=exist_strandness(units)
+        strand=get_strandness(units)
     conda:
         "../envs/pandas.yaml"
     script:

--- a/rules/diffexp.smk
+++ b/rules/diffexp.smk
@@ -5,7 +5,7 @@ rule count_matrix:
         "counts/all.tsv"
     params:
         samples=units["sample"].tolist(),
-        coln=strandedness(units)
+        units=units
     conda:
         "../envs/pandas.yaml"
     script:

--- a/schemas/units.schema.yaml
+++ b/schemas/units.schema.yaml
@@ -14,6 +14,9 @@ properties:
   fq2:
     type: string
     description: path to second FASTQ file (leave empty in case of single-end)
+  strandedness:
+    type: string
+    description: one of the values '0', 'yes' or 'reverse' according to protocol strandedness
 required:
   - sample
   - unit

--- a/scripts/count-matrix.py
+++ b/scripts/count-matrix.py
@@ -1,26 +1,21 @@
 import pandas as pd
 
-def strandedness(units):
+def strandedness(strand_vals):
     strandedness_list = []
-    if "strandedness" in units.columns:
-        for unit in units.itertuples():
-            strand_val = units.loc[(unit.sample, unit.unit), "strandedness"]
-            if pd.isnull(strand_val) or strand_val == "none":
-                strandedness_list.append(1) #non stranded protocol
-            elif strand_val == "yes":
-                strandedness_list.append(2) #3rd column
-            elif strand_val == "reverse":
-                strandedness_list.append(3) #4th column, usually for Illumina truseq
-            else:
-                raise ValueError(("'strandedness' column should be empty or have the " 
+    for strand_val in snakemake.params.strand:
+        if pd.isnull(strand_val) or strand_val == "none":
+            strandedness_list.append(1) #non stranded protocol
+        elif strand_val == "yes":
+            strandedness_list.append(2) #3rd column
+        elif strand_val == "reverse":
+            strandedness_list.append(3) #4th column, usually for Illumina truseq
+        else:
+            raise ValueError(("'strandedness' column should be empty or have the " 
                 "value 'none', 'yes' or 'reverse', instead has the value {}").format(repr(strand_val)))
-    else:
-        strandedness_list.append(1) #non stranded for cases where there isn't a "strandedness" column
-        strandedness_list *= units.shape[0]
     
     return strandedness_list
 
-stranded_list = strandedness(snakemake.params.units)
+stranded_list = strandedness(snakemake.params.strand)
 counts = [pd.read_table(f, index_col=0, usecols=[0, coln], header=None, skiprows=4) \
 for f, coln in zip(snakemake.input, stranded_list)]
 

--- a/scripts/count-matrix.py
+++ b/scripts/count-matrix.py
@@ -1,23 +1,20 @@
 import pandas as pd
 
-def strandedness(strand_vals):
-    strandedness_list = []
-    for strand_val in snakemake.params.strand:
-        if pd.isnull(strand_val) or strand_val == "none":
-            strandedness_list.append(1) #non stranded protocol
-        elif strand_val == "yes":
-            strandedness_list.append(2) #3rd column
-        elif strand_val == "reverse":
-            strandedness_list.append(3) #4th column, usually for Illumina truseq
-        else:
-            raise ValueError(("'strandedness' column should be empty or have the " 
-                "value 'none', 'yes' or 'reverse', instead has the value {}").format(repr(strand_val)))
-    
-    return strandedness_list
+def get_column(strandedness):
+    if pd.isnull(strandedness) or strandedness == "none":
+        return 1 #non stranded protocol
+    elif strandedness == "yes":
+        return 2 #3rd column
+    elif strandedness == "reverse":
+        return 3 #4th column, usually for Illumina truseq
+    else:
+        raise ValueError(("'strandedness' column should be empty or have the " 
+                          "value 'none', 'yes' or 'reverse', instead has the " 
+                          "value {}").format(repr(strandedness)))
 
-stranded_list = strandedness(snakemake.params.strand)
-counts = [pd.read_table(f, index_col=0, usecols=[0, coln], header=None, skiprows=4) \
-for f, coln in zip(snakemake.input, stranded_list)]
+counts = [pd.read_table(f, index_col=0, usecols=[0, get_column(strandedness)], 
+          header=None, skiprows=4) 
+          for f, strandedness in zip(snakemake.input, snakemake.params.strand)]
 
 for t, sample in zip(counts, snakemake.params.samples):
     t.columns = [sample]

--- a/scripts/count-matrix.py
+++ b/scripts/count-matrix.py
@@ -1,7 +1,28 @@
 import pandas as pd
 
+def strandedness(units):
+    strandedness_list = []
+    if "strandedness" in units.columns:
+        for unit in units.itertuples():
+            strand_val = units.loc[(unit.sample, unit.unit), "strandedness"]
+            if pd.isnull(strand_val) or strand_val == "none":
+                strandedness_list.append(1) #non stranded protocol
+            elif strand_val == "yes":
+                strandedness_list.append(2) #3rd column
+            elif strand_val == "reverse":
+                strandedness_list.append(3) #4th column, usually for Illumina truseq
+            else:
+                raise ValueError(("'strandedness' column should be empty or have the " 
+                "value 'none', 'yes' or 'reverse', instead has the value {}").format(repr(strand_val)))
+    else:
+        strandedness_list.append(1) #non stranded for cases where there isn't a "strandedness" column
+        strandedness_list *= units.shape[0]
+    
+    return strandedness_list
+
+stranded_list = strandedness(snakemake.params.units)
 counts = [pd.read_table(f, index_col=0, usecols=[0, coln], header=None, skiprows=4) \
-for f, coln in zip(snakemake.input, snakemake.params.coln)]
+for f, coln in zip(snakemake.input, stranded_list)]
 
 for t, sample in zip(counts, snakemake.params.samples):
     t.columns = [sample]

--- a/scripts/count-matrix.py
+++ b/scripts/count-matrix.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
-counts = [pd.read_table(f, index_col=0, usecols=[0, 1], header=None, skiprows=4)
-          for f in snakemake.input]
+counts = [pd.read_table(f, index_col=0, usecols=[0, coln], header=None, skiprows=4) \
+for f, coln in zip(snakemake.input, snakemake.params.coln)]
 
 for t, sample in zip(counts, snakemake.params.samples):
     t.columns = [sample]


### PR DESCRIPTION
I made changes to use a different column from the `STAR`'s counts output depending on what type of  protocol was used to generate the fastq files. The STAR  output has 3 columns, one for unstranded and two for different types of stranded protocols. This requires an optional column in `units.tsv` called `strandedness`. I also updated the yaml schema leaving this new column optional.

I used the `units` pandas dataframe to iterate for each file and depending on the value (or its absence) of the column `strandedness`, get the column number to be used in `count-matrix.py`. If there isn't a column called `strandedness` it will  use the same column that has been used so far (column `1`).   

The names that I used in the function `strandedness()` , "reverse" and "yes", are the names of the options used in `htseq-count --stranded`,   which is referenced in the `STAR` manual.