### PR TITLE
fix get_contrast

### DIFF
--- a/rules/diffexp.smk
+++ b/rules/diffexp.smk
@@ -67,7 +67,7 @@ rule deseq2:
         table=report("results/diffexp/{contrast}.diffexp.tsv", "../report/diffexp.rst"),
         ma_plot=report("results/diffexp/{contrast}.ma-plot.svg", "../report/ma.rst"),
     params:
-        contrast=get_contrast
+        contrast=get_contrast()
     conda:
         "../envs/deseq2.yaml"
     log:


### PR DESCRIPTION
get_contrast function was without parentheses and it was causing this error:
TypeError in line 77 of /home/curso/Test/dry/rna-seq-star-deseq2/rules/diffexp.smk:
int() argument must be a string, a bytes-like object or a number, not 'function'
  File "/home/curso/Test/dry/rna-seq-star-deseq2/Snakefile", line 48, in <module>
  File "/home/curso/Test/dry/rna-seq-star-deseq2/rules/diffexp.smk", line 77, in <module>