### PR TITLE
gffutils from conda-forge

### DIFF
--- a/envs/gffutils.yaml
+++ b/envs/gffutils.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::gffutils=0.9
+  - gffutils=0.9


### PR DESCRIPTION
when gffutils=0.9 is obtained from bioconda, only gffutils is only available for python2 and this generates a issue because the script needs to run under python 3. When gffutils=0.9 is extracted from conda-forge, then gffutils become available for python 3.