### PR TITLE
Bugfix – Fix broken GitHub Action jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,10 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@2.0.0
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Formatting
       uses: github/super-linter@v4
       env:
@@ -38,10 +39,10 @@ jobs:
       - linting
       - formatting
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v1
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@2.0.0
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Test workflow
       uses: snakemake/snakemake-github-action@v1.22.0
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,8 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout repository
+      uses: actions/checkout@v2
     - name: Linting
       uses: snakemake/snakemake-github-action@v1.22.0
       with:


### PR DESCRIPTION
The GitHub Action jobs were using an unmaintained [git checkout action](https://github.com/textbook/git-checkout-submodule-action) that fails to run. I tested this on my fork of the repository and it passed. You can see the PR and test results from my fork [here](https://github.com/cbp44/rna-seq-star-deseq2/pull/4).

You should allow actions for this PR and merge it in first before merging my other PR (#46).

**Fixes**
- Replace unmaintained actions with official working ones