### PR TITLE
Fix for GitHub Actions, and fix to avoid potential column reordering in count-matrix.py

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
+        fetch-depth: 0
     - name: Formatting
       uses: github/super-linter@v4
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,10 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@2.0.0
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Formatting
       uses: github/super-linter@v4
       env:
@@ -24,7 +25,8 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout repository
+      uses: actions/checkout@v2
     - name: Linting
       uses: snakemake/snakemake-github-action@v1.22.0
       with:
@@ -38,10 +40,10 @@ jobs:
       - linting
       - formatting
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v1
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@2.0.0
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Test workflow
       uses: snakemake/snakemake-github-action@v1.22.0
       with:

--- a/workflow/scripts/count-matrix.py
+++ b/workflow/scripts/count-matrix.py
@@ -36,5 +36,5 @@ for t, sample in zip(counts, snakemake.params.samples):
 matrix = pd.concat(counts, axis=1)
 matrix.index.name = "gene"
 # collapse technical replicates
-matrix = matrix.groupby(matrix.columns, axis=1).sum()
+matrix = matrix.groupby(matrix.columns, axis=1, sort=False).sum()
 matrix.to_csv(snakemake.output[0], sep="\t")


### PR DESCRIPTION
- Another shot at trying to get GitHub Actions working. The tests pass on my master branch as shown [here](https://github.com/cbp44/rna-seq-star-deseq2/actions/runs/1518836261).
- Fix for issue #32.

  An analysis can fail if the `count-matrix.py` script inconsistently sorts output columns. The default behavior of the `pandas.matrix.groupby` function is to sort the grouping keys, but the sorting is not stable and causes the workflow to fail sometimes in the `deseq2_init` rule of the analysis if the sorting happened to change the order.

  I ran into this bug a while ago and it prevented analyses where I had dozens of units in the `units.tsv` file that spanned sequencing lanes.
