### PR TITLE
improve environment specifications

### DIFF
--- a/workflow/envs/biomart.yaml
+++ b/workflow/envs/biomart.yaml
@@ -1,6 +1,7 @@
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
 dependencies:
+  - r-base =4.0
   - bioconductor-biomart =2.46
   - r-tidyverse =1.3

--- a/workflow/envs/deseq2.yaml
+++ b/workflow/envs/deseq2.yaml
@@ -1,6 +1,7 @@
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
 dependencies:
+  - r-base =4.0
   - bioconductor-deseq2 =1.30.0
   - r-ashr =2.2_47


### PR DESCRIPTION
The Bioconda specification is `conda-forge > bioconda`, so this corrects that. Additionally, all Bioconductor packages are tied to a single version fo R. Explicitly specifying this in a YAML often improves solve times (especially noticeable for `conda` frontend).