### PR TITLE
fix: stable column ordering in count-matrix.py

### DIFF
--- a/workflow/scripts/count-matrix.py
+++ b/workflow/scripts/count-matrix.py
@@ -36,5 +36,5 @@ for t, sample in zip(counts, snakemake.params.samples):
 matrix = pd.concat(counts, axis=1)
 matrix.index.name = "gene"
 # collapse technical replicates
-matrix = matrix.groupby(matrix.columns, axis=1).sum()
+matrix = matrix.groupby(matrix.columns, axis=1, sort=False).sum()
 matrix.to_csv(snakemake.output[0], sep="\t")


### PR DESCRIPTION
Fix for issue #32.

Some analyses fail because the `count-matrix.py` script inconsistently sorts output columns, especially when there are lots of units in the `units.tsv` file that span multiple sequencing lanes.

The default behavior of the `pandas.matrix.groupby` function is to sort the grouping keys, but the sorting is not stable and causes the workflow to fail sometimes in the `deseq2_init` rule of the analysis if the sorting happened to change the column ordering.

---

Originally from PR #49. Please close that PR without merging @dlaehnemann
