### PR TITLE
fixed trimmed fastq filename in get_fq()

### DIFF
--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -3,10 +3,10 @@ rule align:
         unpack(get_fq),
         index="resources/star_genome",
     output:
-        aln="results/star/{sample}-{unit}/Aligned.sortedByCoord.out.bam",
-        reads_per_gene="results/star/{sample}-{unit}/ReadsPerGene.out.tab",
+        aln="results/star/{sample}_{unit}/Aligned.sortedByCoord.out.bam",
+        reads_per_gene="results/star/{sample}_{unit}/ReadsPerGene.out.tab",
     log:
-        "logs/star/{sample}-{unit}.log",
+        "logs/star/{sample}_{unit}.log",
     params:
         idx=lambda wc, input: input.index,
         extra="--outSAMtype BAM SortedByCoordinate --quantMode GeneCounts --sjdbGTFfile {} {}".format(

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -95,14 +95,14 @@ def get_fq(wildcards):
                 zip(
                     ["fq1", "fq2"],
                     expand(
-                        "results/trimmed/{sample}-{unit}_{group}.fastq.gz",
+                        "results/trimmed/{sample}_{unit}_{group}.fastq.gz",
                         group=["R1", "R2"],
                         **wildcards,
                     ),
                 )
             )
         # single end sample
-        return {"fq1": "trimmed/{sample}-{unit}_single.fastq.gz".format(**wildcards)}
+        return {"fq1": "trimmed/{sample}_{unit}_single.fastq.gz".format(**wildcards)}
     else:
         # no trimming, use raw reads
         u = units.loc[(wildcards.sample, wildcards.unit), ["fq1", "fq2"]].dropna()

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -95,14 +95,14 @@ def get_fq(wildcards):
                 zip(
                     ["fq1", "fq2"],
                     expand(
-                        "results/trimmed/{sample}_{unit}_{group}.fastq.gz",
+                        "results/trimmed/{sample}-{unit}_{group}.fastq.gz",
                         group=["R1", "R2"],
                         **wildcards,
                     ),
                 )
             )
         # single end sample
-        return {"fq1": "trimmed/{sample}_{unit}_single.fastq.gz".format(**wildcards)}
+        return {"fq1": "trimmed/{sample}-{unit}_single.fastq.gz".format(**wildcards)}
     else:
         # no trimming, use raw reads
         u = units.loc[(wildcards.sample, wildcards.unit), ["fq1", "fq2"]].dropna()

--- a/workflow/rules/diffexp.smk
+++ b/workflow/rules/diffexp.smk
@@ -1,7 +1,7 @@
 rule count_matrix:
     input:
         expand(
-            "results/star/{unit.sample_name}-{unit.unit_name}/ReadsPerGene.out.tab",
+            "results/star/{unit.sample_name}_{unit.unit_name}/ReadsPerGene.out.tab",
             unit=units.itertuples(),
         ),
     output:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -17,13 +17,13 @@ rule rseqc_gtf2bed:
 
 rule rseqc_junction_annotation:
     input:
-        bam="results/star/{sample}-{unit}/Aligned.sortedByCoord.out.bam",
+        bam="results/star/{sample}_{unit}/Aligned.sortedByCoord.out.bam",
         bed="results/qc/rseqc/annotation.bed",
     output:
-        "results/qc/rseqc/{sample}-{unit}.junctionanno.junction.bed",
+        "results/qc/rseqc/{sample}_{unit}.junctionanno.junction.bed",
     priority: 1
     log:
-        "logs/rseqc/rseqc_junction_annotation/{sample}-{unit}.log",
+        "logs/rseqc/rseqc_junction_annotation/{sample}_{unit}.log",
     params:
         extra=r"-q 255",  # STAR uses 255 as a score for unique mappers
         prefix=lambda w, output: output[0].replace(".junction.bed", ""),
@@ -36,13 +36,13 @@ rule rseqc_junction_annotation:
 
 rule rseqc_junction_saturation:
     input:
-        bam="results/star/{sample}-{unit}/Aligned.sortedByCoord.out.bam",
+        bam="results/star/{sample}_{unit}/Aligned.sortedByCoord.out.bam",
         bed="results/qc/rseqc/annotation.bed",
     output:
-        "results/qc/rseqc/{sample}-{unit}.junctionsat.junctionSaturation_plot.pdf",
+        "results/qc/rseqc/{sample}_{unit}.junctionsat.junctionSaturation_plot.pdf",
     priority: 1
     log:
-        "logs/rseqc/rseqc_junction_saturation/{sample}-{unit}.log",
+        "logs/rseqc/rseqc_junction_saturation/{sample}_{unit}.log",
     params:
         extra=r"-q 255",
         prefix=lambda w, output: output[0].replace(".junctionSaturation_plot.pdf", ""),
@@ -55,12 +55,12 @@ rule rseqc_junction_saturation:
 
 rule rseqc_stat:
     input:
-        "results/star/{sample}-{unit}/Aligned.sortedByCoord.out.bam",
+        "results/star/{sample}_{unit}/Aligned.sortedByCoord.out.bam",
     output:
-        "results/qc/rseqc/{sample}-{unit}.stats.txt",
+        "results/qc/rseqc/{sample}_{unit}.stats.txt",
     priority: 1
     log:
-        "logs/rseqc/rseqc_stat/{sample}-{unit}.log",
+        "logs/rseqc/rseqc_stat/{sample}_{unit}.log",
     conda:
         "../envs/rseqc.yaml"
     shell:
@@ -69,13 +69,13 @@ rule rseqc_stat:
 
 rule rseqc_infer:
     input:
-        bam="results/star/{sample}-{unit}/Aligned.sortedByCoord.out.bam",
+        bam="results/star/{sample}_{unit}/Aligned.sortedByCoord.out.bam",
         bed="results/qc/rseqc/annotation.bed",
     output:
-        "results/qc/rseqc/{sample}-{unit}.infer_experiment.txt",
+        "results/qc/rseqc/{sample}_{unit}.infer_experiment.txt",
     priority: 1
     log:
-        "logs/rseqc/rseqc_infer/{sample}-{unit}.log",
+        "logs/rseqc/rseqc_infer/{sample}_{unit}.log",
     conda:
         "../envs/rseqc.yaml"
     shell:
@@ -84,13 +84,13 @@ rule rseqc_infer:
 
 rule rseqc_innerdis:
     input:
-        bam="results/star/{sample}-{unit}/Aligned.sortedByCoord.out.bam",
+        bam="results/star/{sample}_{unit}/Aligned.sortedByCoord.out.bam",
         bed="results/qc/rseqc/annotation.bed",
     output:
-        "results/qc/rseqc/{sample}-{unit}.inner_distance_freq.inner_distance.txt",
+        "results/qc/rseqc/{sample}_{unit}.inner_distance_freq.inner_distance.txt",
     priority: 1
     log:
-        "logs/rseqc/rseqc_innerdis/{sample}-{unit}.log",
+        "logs/rseqc/rseqc_innerdis/{sample}_{unit}.log",
     params:
         prefix=lambda w, output: output[0].replace(".inner_distance.txt", ""),
     conda:
@@ -101,13 +101,13 @@ rule rseqc_innerdis:
 
 rule rseqc_readdis:
     input:
-        bam="results/star/{sample}-{unit}/Aligned.sortedByCoord.out.bam",
+        bam="results/star/{sample}_{unit}/Aligned.sortedByCoord.out.bam",
         bed="results/qc/rseqc/annotation.bed",
     output:
-        "results/qc/rseqc/{sample}-{unit}.readdistribution.txt",
+        "results/qc/rseqc/{sample}_{unit}.readdistribution.txt",
     priority: 1
     log:
-        "logs/rseqc/rseqc_readdis/{sample}-{unit}.log",
+        "logs/rseqc/rseqc_readdis/{sample}_{unit}.log",
     conda:
         "../envs/rseqc.yaml"
     shell:
@@ -116,12 +116,12 @@ rule rseqc_readdis:
 
 rule rseqc_readdup:
     input:
-        "results/star/{sample}-{unit}/Aligned.sortedByCoord.out.bam",
+        "results/star/{sample}_{unit}/Aligned.sortedByCoord.out.bam",
     output:
-        "results/qc/rseqc/{sample}-{unit}.readdup.DupRate_plot.pdf",
+        "results/qc/rseqc/{sample}_{unit}.readdup.DupRate_plot.pdf",
     priority: 1
     log:
-        "logs/rseqc/rseqc_readdup/{sample}-{unit}.log",
+        "logs/rseqc/rseqc_readdup/{sample}_{unit}.log",
     params:
         prefix=lambda w, output: output[0].replace(".DupRate_plot.pdf", ""),
     conda:
@@ -132,12 +132,12 @@ rule rseqc_readdup:
 
 rule rseqc_readgc:
     input:
-        "results/star/{sample}-{unit}/Aligned.sortedByCoord.out.bam",
+        "results/star/{sample}_{unit}/Aligned.sortedByCoord.out.bam",
     output:
-        "results/qc/rseqc/{sample}-{unit}.readgc.GC_plot.pdf",
+        "results/qc/rseqc/{sample}_{unit}.readgc.GC_plot.pdf",
     priority: 1
     log:
-        "logs/rseqc/rseqc_readgc/{sample}-{unit}.log",
+        "logs/rseqc/rseqc_readgc/{sample}_{unit}.log",
     params:
         prefix=lambda w, output: output[0].replace(".GC_plot.pdf", ""),
     conda:
@@ -149,43 +149,43 @@ rule rseqc_readgc:
 rule multiqc:
     input:
         expand(
-            "results/star/{unit.sample_name}-{unit.unit_name}/Aligned.sortedByCoord.out.bam",
+            "results/star/{unit.sample_name}_{unit.unit_name}/Aligned.sortedByCoord.out.bam",
             unit=units.itertuples(),
         ),
         expand(
-            "results/qc/rseqc/{unit.sample_name}-{unit.unit_name}.junctionanno.junction.bed",
+            "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.junctionanno.junction.bed",
             unit=units.itertuples(),
         ),
         expand(
-            "results/qc/rseqc/{unit.sample_name}-{unit.unit_name}.junctionsat.junctionSaturation_plot.pdf",
+            "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.junctionsat.junctionSaturation_plot.pdf",
             unit=units.itertuples(),
         ),
         expand(
-            "results/qc/rseqc/{unit.sample_name}-{unit.unit_name}.infer_experiment.txt",
+            "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.infer_experiment.txt",
             unit=units.itertuples(),
         ),
         expand(
-            "results/qc/rseqc/{unit.sample_name}-{unit.unit_name}.stats.txt",
+            "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.stats.txt",
             unit=units.itertuples(),
         ),
         expand(
-            "results/qc/rseqc/{unit.sample_name}-{unit.unit_name}.inner_distance_freq.inner_distance.txt",
+            "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.inner_distance_freq.inner_distance.txt",
             unit=units.itertuples(),
         ),
         expand(
-            "results/qc/rseqc/{unit.sample_name}-{unit.unit_name}.readdistribution.txt",
+            "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.readdistribution.txt",
             unit=units.itertuples(),
         ),
         expand(
-            "results/qc/rseqc/{unit.sample_name}-{unit.unit_name}.readdup.DupRate_plot.pdf",
+            "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.readdup.DupRate_plot.pdf",
             unit=units.itertuples(),
         ),
         expand(
-            "results/qc/rseqc/{unit.sample_name}-{unit.unit_name}.readgc.GC_plot.pdf",
+            "results/qc/rseqc/{unit.sample_name}_{unit.unit_name}.readgc.GC_plot.pdf",
             unit=units.itertuples(),
         ),
         expand(
-            "logs/rseqc/rseqc_junction_annotation/{unit.sample_name}-{unit.unit_name}.log",
+            "logs/rseqc/rseqc_junction_annotation/{unit.sample_name}_{unit.unit_name}.log",
             unit=units.itertuples(),
         ),
     output:

--- a/workflow/rules/trim.smk
+++ b/workflow/rules/trim.smk
@@ -14,7 +14,7 @@ rule cutadapt_pipe:
     output:
         pipe("pipe/cutadapt/{sample}/{unit}.{fq}.{ext}"),
     log:
-        "logs/pipe-fastqs/catadapt/{sample}-{unit}.{fq}.{ext}.log",
+        "logs/pipe-fastqs/catadapt/{sample}_{unit}.{fq}.{ext}.log",
     wildcard_constraints:
         ext=r"fastq|fastq\.gz",
     threads: 0
@@ -26,11 +26,11 @@ rule cutadapt_pe:
     input:
         get_cutadapt_input,
     output:
-        fastq1="results/trimmed/{sample}-{unit}_R1.fastq.gz",
-        fastq2="results/trimmed/{sample}-{unit}_R2.fastq.gz",
-        qc="results/trimmed/{sample}-{unit}.paired.qc.txt",
+        fastq1="results/trimmed/{sample}_{unit}_R1.fastq.gz",
+        fastq2="results/trimmed/{sample}_{unit}_R2.fastq.gz",
+        qc="results/trimmed/{sample}_{unit}.paired.qc.txt",
     log:
-        "logs/cutadapt/{sample}-{unit}.log",
+        "logs/cutadapt/{sample}_{unit}.log",
     params:
         others=config["params"]["cutadapt-pe"],
         adapters=lambda w: str(units.loc[w.sample].loc[w.unit, "adapters"]),
@@ -43,10 +43,10 @@ rule cutadapt_se:
     input:
         get_cutadapt_input,
     output:
-        fastq="results/trimmed/{sample}-{unit}_single.fastq.gz",
-        qc="results/trimmed/{sample}-{unit}_single.qc.txt",
+        fastq="results/trimmed/{sample}_{unit}_single.fastq.gz",
+        qc="results/trimmed/{sample}_{unit}_single.qc.txt",
     log:
-        "logs/cutadapt/{sample}-{unit}.log",
+        "logs/cutadapt/{sample}_{unit}.log",
     params:
         others=config["params"]["cutadapt-se"],
         adapters_r1=lambda w: str(units.loc[w.sample].loc[w.unit, "adapters"]),


### PR DESCRIPTION
Currently, the output of the cutadapt_pe and cutadapt_se recipes (in the trim.smk) have the pattern `results/trimmed/{sample}-{unit}_R1.fastq.gz` and `results/trimmed/{sample}-{unit}_single.fastq.gz`, respectively. However the get_fq() function (in common.smk) refers to these files as `results/trimmed/{sample}_{unit}_{group}.fastq.gz` and `trimmed/{sample}_{unit}_single.fastq.gz` (notice the underscore between `{sample}` and `{unit}` instead of a hyphen). Because of this the pipeline fails when trimming is activated.

In this bug fix,  I changed the get_fq() function to refer to the files using the hyphen. 