### PR TITLE
fix: make specification of SRA samples in samples.tsv work (common.smk)

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -105,7 +105,7 @@ def get_fq(wildcards):
         return {"fq1": "trimmed/{sample}_{unit}_single.fastq.gz".format(**wildcards)}
     else:
         # no trimming, use raw reads
-        u = units.loc[(wildcards.sample, wildcards.unit), ["fq1", "fq2"]].dropna()
+        u = units.loc[(wildcards.sample, wildcards.unit)]
         if pd.isna(u["fq1"]):
             # SRA sample (always paired-end for now)
             accession = u["sra"]


### PR DESCRIPTION
Previously, `u` was restricted to columns `["fq1", "fq2"]` and any found entry dropped altogether if both entries are `NA`. Now, this simply selects one entry in `samples.tsv` and all the necessary columns should still be there for proper handling in the following lines.

closes #52