### PR TITLE
fix: Fixing workflow for single-end sequencing

### DIFF
--- a/workflow/envs/biomart.yaml
+++ b/workflow/envs/biomart.yaml
@@ -5,3 +5,7 @@ channels:
 dependencies:
   - bioconductor-biomart =2.56
   - r-tidyverse =2.0
+  # remove once we can update to bioconductor-biomart of the 3.18 release, which will
+  # include this proper fix for the underlying compatibility issue:
+  # https://github.com/Bioconductor/BiocFileCache/pull/50
+  - r-dbplyr=2.3.4

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -119,7 +119,9 @@ def get_fq(wildcards):
                 )
             )
         # single end sample
-        return {"fq1": "results/trimmed/{sample}_{unit}_single.fastq.gz".format(**wildcards)}
+        return {
+            "fq1": "results/trimmed/{sample}_{unit}_single.fastq.gz".format(**wildcards)
+        }
     else:
         # no trimming, use raw reads
         u = units.loc[(wildcards.sample, wildcards.unit)]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -119,7 +119,7 @@ def get_fq(wildcards):
                 )
             )
         # single end sample
-        return {"fq1": "trimmed/{sample}_{unit}_single.fastq.gz".format(**wildcards)}
+        return {"fq1": "results/trimmed/{sample}_{unit}_single.fastq.gz".format(**wildcards)}
     else:
         # no trimming, use raw reads
         u = units.loc[(wildcards.sample, wildcards.unit)]

--- a/workflow/rules/trim.smk
+++ b/workflow/rules/trim.smk
@@ -49,7 +49,7 @@ rule cutadapt_se:
         "logs/cutadapt/{sample}_{unit}.log",
     params:
         extra=config["params"]["cutadapt-se"],
-        adapters_r1=lambda w: str(units.loc[w.sample].loc[w.unit, "adapters"]),
+        adapters=lambda w: str(units.loc[w.sample].loc[w.unit, "adapters"]),
     threads: 8
     wrapper:
         "v1.21.4/bio/cutadapt/se"

--- a/workflow/scripts/gene2symbol.R
+++ b/workflow/scripts/gene2symbol.R
@@ -1,5 +1,7 @@
 library(biomaRt)
 library(tidyverse)
+# useful error messages upon aborting
+library("cli")
 
 # this variable holds a mirror name until
 # useEnsembl succeeds ("www" is last, because 
@@ -24,7 +26,14 @@ while ( class(mart)[[1]] != "Mart" ) {
       # change or make configurable if you want more or
       # less rounds of tries of all the mirrors
       if (rounds >= 3) {
-        stop(
+        cli_abort(
+          str_c(
+            "Have tried all 4 available Ensembl biomaRt mirrors ",
+            rounds,
+            " times. You might have a connection problem, or no mirror is responsive.\n",
+            "The last error message was:\n",
+            message(e)
+          )
         )
       }
       # hop to next mirror


### PR DESCRIPTION
## Summary

This PR fixes minor issues stopping the workflow from working with SE sequences.

## Bugs Fixed
* Fixes path in `get_fq` to appropriately look in `results/trimmed/` instead of `trimmed/`
* Changes `cutadapt/se` wrapper to call `adapters` not `adapters_r1`. While the wrapper (found [here](https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/cutadapt/se.html)) seems to want users to separate adapter args from extra args, they appear to be equivalent. This is how the PE workflow works and verifying the STAR commands suggests that this is fine.