### PR TITLE
fix: update to using storage plugin ftp

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,7 +1,7 @@
 from snakemake.utils import min_version
 
 ##### set minimum snakemake version #####
-min_version("6.4.1")
+min_version("8.8.0")
 
 
 ##### setup report #####

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1,7 +1,6 @@
 import glob
 
 import pandas as pd
-from snakemake.remote import FTP
 from snakemake.utils import validate
 
 validate(config, schema="../schemas/config.schema.yaml")

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -4,8 +4,6 @@ import pandas as pd
 from snakemake.remote import FTP
 from snakemake.utils import validate
 
-ftp = FTP.RemoteProvider()
-
 validate(config, schema="../schemas/config.schema.yaml")
 
 samples = (


### PR DESCRIPTION
Migration to using `snakemake >=v8.0.0` requires switching to use plugins:
https://snakemake.readthedocs.io/en/latest/getting_started/migration.html

In the case of remote providers, these are now implemented as storage plugins. Here we switch to the new FTP storage plugin:
https://snakemake.github.io/snakemake-plugin-catalog/plugins/storage/ftp.html

I hope that this closes #74 .