### PR TITLE
fix: use derived input for star_index

### DIFF
--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -63,7 +63,7 @@ rule star_index:
         directory("resources/star_genome"),
     threads: 4
     params:
-        extra="--sjdbGTFfile resources/genome.gtf --sjdbOverhang 100",
+        extra= lambda wc, input: f'--sjdbGTFfile {input.annotation} --sjdbOverhang 100',
     log:
         "logs/star_index_genome.log",
     cache: True

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -63,7 +63,7 @@ rule star_index:
         directory("resources/star_genome"),
     threads: 4
     params:
-        extra= lambda wc, input: f'--sjdbGTFfile {input.annotation} --sjdbOverhang 100',
+        extra=lambda wc, input: f"--sjdbGTFfile {input.annotation} --sjdbOverhang 100",
     log:
         "logs/star_index_genome.log",
     cache: True


### PR DESCRIPTION
the file path for the -sjdbGTFfile parameter was hardcoded to 'resources/genome.gtf' which causes execution to fail due to missing files on remote execution environments without a shared filesystem (such as kubernetes)

This derives the filepath correctly from the input property to fix this issue