### PR TITLE
Update rseqc.yaml

### DIFF
--- a/workflow/envs/rseqc.yaml
+++ b/workflow/envs/rseqc.yaml
@@ -3,4 +3,6 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - rseqc =5.0
+  - rseqc=5.0
+  - r-base
+  - r-essentials


### PR DESCRIPTION
typos in env causing errors and if system R is not installed, this env fails to find Rscript.

Apologies for the 4 tiny PRs, I could only send these on via the UI and figured it was worth the annoying multi-prs.