### PR TITLE
fix: consistently provide extra params for star rules

### DIFF
--- a/.test/config_basic/config.yaml
+++ b/.test/config_basic/config.yaml
@@ -34,4 +34,6 @@ diffexp:
   model: ~condition
 
 params:
-  star: ""
+  star:
+    index: ""
+    align: ""

--- a/.test/config_complex/config.yaml
+++ b/.test/config_complex/config.yaml
@@ -41,4 +41,7 @@ diffexp:
   model: ""
 
 params:
-  star: ""
+  star:
+    index: ""
+    align: ""
+

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -65,5 +65,16 @@ diffexp:
   model: ""
 
 
+# passing extra parameters to respective rules in the workflow
 params:
-  star: ""
+  star:
+    # For extra parameters you can pass to the star indexing wrapper, see the
+    # wrapper documentation and the star documentation:
+    # - https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/bio/star/index.html
+    # - https://github.com/alexdobin/STAR?tab=readme-ov-file#manual
+    index: ""
+    # For extra parameters you can pass to the star alignment wrapper, see the
+    # wrapper documentation and the star documentation:
+    # - https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/bio/star/align.html
+    # - https://github.com/alexdobin/STAR?tab=readme-ov-file#manual
+    align: ""

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -1,4 +1,4 @@
-rule align:
+rule star_align:
     input:
         unpack(get_fq),
         idx="resources/star_genome",
@@ -9,7 +9,10 @@ rule align:
     log:
         "logs/star/{sample}-{unit}.log",
     params:
-        extra=lambda wc, input: f'--outSAMtype BAM SortedByCoordinate --quantMode GeneCounts --sjdbGTFfile {input.gtf} {config["params"]["star"]}',
+        extra=lambda wc, input:
+            ' --outSAMtype BAM SortedByCoordinate --quantMode GeneCounts '
+            f' --sjdbGTFfile {input.gtf} '
+            f' {lookup(within=config, dpath="params/star/align", default="")} ',
     threads: 24
     wrapper:
         "v7.2.0/bio/star/align"

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -60,9 +60,11 @@ rule star_index:
         gtf="resources/genome.gtf",
     output:
         directory("resources/star_genome"),
-    threads: 4
     log:
         "logs/star_index_genome.log",
     cache: True
+    params:
+        extra=lookup(within=config, dpath="params/star/index", default=""),
+    threads: 4
     wrapper:
         "v7.2.0/bio/star/index"

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -60,7 +60,15 @@ properties:
     type: object
     properties:
       star: 
-        type: string
+        type: object
+        properties:
+          index:
+            type: string
+          align:
+            type: string
+        required:
+          - index
+          - align
     required:
       - star
 


### PR DESCRIPTION
This should have really been in the previous PR #93 , but rather late then never...